### PR TITLE
Updated Rver to 3.2.2.

### DIFF
--- a/RRO-src/files/windows/JRins.R
+++ b/RRO-src/files/windows/JRins.R
@@ -32,7 +32,7 @@
     SVN <- sub("Revision: ", "", readLines("../../../SVN-REVISION"))[1L]
     SVN <- as.character(as.numeric(SVN) - 50000L)
     Rver0 <- paste(sub(" .*$", "", Rver), SVN, sep = ".")
-    Rver <- "3.2.1"
+    Rver <- "3.2.2"
 
 
     con <- file("R.iss", "w")


### PR DESCRIPTION
This _should_ fix the 3.2.1 version number problem in the Windows installer.